### PR TITLE
fix (Assets): change EthanDiffuse.png to RGBA32 format

### DIFF
--- a/Assets/Textures/EthanDiffuse.png.meta
+++ b/Assets/Textures/EthanDiffuse.png.meta
@@ -71,7 +71,7 @@ TextureImporter:
     buildTarget: DefaultTexturePlatform
     maxTextureSize: 2048
     resizeAlgorithm: 0
-    textureFormat: -1
+    textureFormat: 4
     textureCompression: 1
     compressionQuality: 50
     crunchedCompression: 0


### PR DESCRIPTION
reason: this fixes the crash when trying to convert the texture data to uncompressed format from BC1 (DXTC1)
